### PR TITLE
fix(ci): 放行 scripts/lib 下被误忽略的 quality-baseline 源码模块

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm smoke:better-sqlite3
       - run: pnpm check:drizzle
       - run: pnpm --filter @nekro-nxt/storage-sqlite test

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 dist/
 build/
 lib/
+!scripts/lib/
+!scripts/lib/quality-baseline.mjs
 coverage/
 .turbo/
 .tsbuildinfo

--- a/scripts/lib/quality-baseline.mjs
+++ b/scripts/lib/quality-baseline.mjs
@@ -1,0 +1,41 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+export function countsFromFindings(findings) {
+  const counts = {}
+  for (const finding of findings) {
+    const byFile = (counts[finding.rule] ??= {})
+    byFile[finding.file] = (byFile[finding.file] ?? 0) + 1
+  }
+  return sortCounts(counts)
+}
+
+export function sortCounts(counts) {
+  return Object.fromEntries(
+    Object.entries(counts)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([rule, files]) => [
+        rule,
+        Object.fromEntries(Object.entries(files).sort(([left], [right]) => left.localeCompare(right))),
+      ]),
+  )
+}
+
+export function compareCounts(actual, baseline) {
+  const regressions = []
+  for (const [rule, files] of Object.entries(actual)) {
+    for (const [file, count] of Object.entries(files)) {
+      const allowed = baseline[rule]?.[file] ?? 0
+      if (count > allowed) regressions.push({ rule, file, count, allowed })
+    }
+  }
+  return regressions
+}
+
+export async function readBaseline(root, relativePath) {
+  return JSON.parse(await readFile(path.join(root, relativePath), 'utf8'))
+}
+
+export async function writeBaseline(root, relativePath, value) {
+  await writeFile(path.join(root, relativePath), `${JSON.stringify(value, null, 2)}\n`)
+}


### PR DESCRIPTION
## 背景
最新 main 提交  的 CI 失败：'Cannot find module .../quality-baseline.mjs' 导致 quality 的 `pnpm check` 和 node-compat 的 `pnpm check:drizzle` 双双失败。

## 根因
`.gitignore` 第5行的裸规则 `lib/` 本意是排除各包构建产物（apps/**/lib、packages/**/lib 等 15 处），却把 **源码目录** `scripts/lib/` 也误伤忽略。`scripts/lib/quality-baseline.mjs` 因此从未进入仓库，CI checkout 后缺失该模块，多个 check 脚本 import 直接崩。

## 修复
在 `.gitignore` 中对 `scripts/lib/` 加两行白名单放行，将该公共源码模块纳入版本管理。`quality-baseline.mjs` 内容取自已修好的本地工作区（含 prettier 格式化）。

## 验证（本地全绿）
- `pnpm check` → exit 0（format/typecheck/lint/static/drizzle/workspace/ui 等全过）
- quality-baseline.spec 2 个测试全过
- `pnpm smoke:better-sqlite3` → passed